### PR TITLE
fix(server): correctly remove cookies

### DIFF
--- a/src/server/server-cookies.service.ts
+++ b/src/server/server-cookies.service.ts
@@ -41,7 +41,11 @@ export class ServerCookiesService extends CookiesService {
       options?: CookiesOptions
     ) => {
       this.newCookies[name] = value;
-      this.response.cookie(name, value, this.buildCookiesOptions(options));
+      if(value == undefined) { // null or undefined
+        this.response.clearCookie(name, this.buildCookiesOptions(options));
+      } else {
+        this.response.cookie(name, value, this.buildCookiesOptions(options));
+      }
     };
   }
 


### PR DESCRIPTION
`cookieService.remove` calls `cookieService.put` with the value of `undefined`.
When the value is undefined (or null), `response.clearCookie` should be used.
Alternatively, we could call `response.cookie` with proper expiry option and an empty string value, but this is already done in [clearCookie method of express response object](https://github.com/expressjs/express/blob/dc538f6e810bd462c98ee7e6aae24c64d4b1da93/lib/response.js#L797).